### PR TITLE
fix - killing floaty leaves behind scope

### DIFF
--- a/dragon-drop.js
+++ b/dragon-drop.js
@@ -95,6 +95,7 @@ angular.module('btford.dragon-drop', []).
     var killFloaty = function () {
       if (floaty) {
         $document.unbind('mousemove', drag);
+        floaty.scope().$destroy();
         floaty.remove();
         floaty = null;
       }


### PR DESCRIPTION
I noticed extra scopes being left behind after dropping which turned out belonging to the spawned floaty. I simply added a scope.$destroy() inside killFloaty() to clean these up.
