### PR TITLE
Turn user-select back on when floaty is killed.

### DIFF
--- a/dragon-drop.js
+++ b/dragon-drop.js
@@ -97,6 +97,7 @@ angular.module('btford.dragon-drop', []).
         $document.unbind('mousemove', drag);
         floaty.remove();
         floaty = null;
+        enableSelect();
       }
     };
 


### PR DESCRIPTION
enableSelect is defined but never used in the original code.
