### PR TITLE
Evaluate 'btf-dragon-drop' callback if an item was dropped on a target a...

### DIFF
--- a/dragon-drop.js
+++ b/dragon-drop.js
@@ -145,12 +145,17 @@ angular.module('btford.dragon-drop', []).
 
       if (dropArea.length > 0) {
         var expression = dropArea.attr('btf-dragon');
+        var dropCallback = dropArea.attr('btf-dragon-drop');
         var targetScope = dropArea.scope();
         var match = expression.match(/^\s*(.+)\s+in\s+(.*?)\s*$/);
 
         var targetList = targetScope.$eval(match[2]);
+        var targetCallback = targetScope.$eval(dropCallback);
         targetScope.$apply(function () {
           add(targetList, dragValue, dragKey);
+          if (targetCallback && angular.isFunction(targetCallback)) {
+            targetCallback(dragValue, dragKey);
+          }
         });
       } else if (!dragDuplicate) {
         // no dropArea here

--- a/example.html
+++ b/example.html
@@ -27,7 +27,7 @@
       </div>
       <div class="span6">
         <h3>Other Things</h3>
-        <div btf-dragon="thing in otherThings">{{thing}}</div>
+        <div btf-dragon="thing in otherThings" btf-dragon-drop="dropCallback">{{thing}}</div>
       </div>
     </div>
     
@@ -53,6 +53,9 @@
       controller('MainCtrl', function ($scope) {
         $scope.things = ['one', 'two', 'three'];
         $scope.otherThings = [];
+        $scope.dropCallback = function(value, key) {
+          console.log('Value:', value, 'Key:', key);
+        }
       });
   </script>
 </body>


### PR DESCRIPTION
I guessed it would be useful to have a callback if an item was dropped on a target area.
If a 'btf-dragon-drop' attribute is present on the target element any underlying function gets evaluated with the dragValue and dragKey values respectively.
